### PR TITLE
Update rds.py

### DIFF
--- a/troposphere/rds.py
+++ b/troposphere/rds.py
@@ -163,7 +163,7 @@ class DBInstance(AWSObject):
             invalid_replica_properties = (
                 'BackupRetentionPeriod', 'DBName', 'MasterUsername',
                 'MasterUserPassword', 'PreferredBackupWindow', 'MultiAZ',
-                'DBSnapshotIdentifier', 'DBSubnetGroupName',
+                'DBSnapshotIdentifier',
             )
 
             invalid_properties = [s for s in self.properties.keys() if


### PR DESCRIPTION
DBSubnetGroupName is not incompatible with SourceDBInstanceIdentifier, as can be observed in the reference: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-sourcedbinstanceidentifier I required to create a replica db in a custom VPC, instead of using the default VPC. For doing that is necessary to use DBSubnetGroupName. I modified the template manually and it worked perfectly.
